### PR TITLE
Add copyright notice to footer

### DIFF
--- a/insegel/footer.html
+++ b/insegel/footer.html
@@ -29,6 +29,13 @@
                 </li>
             {% endif %}
         </ul>
+
+        {% if copyright %}
+            <div id="copyright">
+                &copy; {{ copyright }}
+            </div>
+        {% endif %}
+
         <div id="credit">
             created with <a href="http://sphinx-doc.org/">Sphinx</a> and <a href="https://github.com/Autophagy/insegel">Insegel</a>
 


### PR DESCRIPTION
Add support for a copyright notice in the centre of the footer.