### PR TITLE
Fixed incompatability with nbshpinx.

### DIFF
--- a/insegel/static/css/insegel.css
+++ b/insegel/static/css/insegel.css
@@ -168,6 +168,10 @@ pre code {
   overflow-x: auto;
 }
 
+div.highlight > pre {
+  white-space: pre-wrap;
+}
+
 code {
   max-width: 100%;
   padding: 2px;


### PR DESCRIPTION
Python warnings from notebooks would be written to pre-tags, with
long error messages overflowing the flex layout. Now pre-tags
within highlight divs (`div.highlight`) wrap code.